### PR TITLE
prevent connections from starting transaction

### DIFF
--- a/wrds/sql.py
+++ b/wrds/sql.py
@@ -83,6 +83,7 @@ class Connection(object):
                     host=self._hostname,
                     port=self._port,
                     dbname=self._dbname),
+                isolation_level="AUTOCOMMIT",
                 connect_args=self._connect_args)
         # No username passed in, but other parameters might have been.
         else:
@@ -92,6 +93,7 @@ class Connection(object):
                     host=self._hostname,
                     port=self._port,
                     dbname=self._dbname),
+                isolation_level="AUTOCOMMIT",
                 connect_args=self._connect_args)
         if (autoconnect):
             self.connect()
@@ -112,6 +114,7 @@ class Connection(object):
                     host=self._hostname,
                     port=self._port,
                     dbname=self._dbname),
+                isolation_level="AUTOCOMMIT",
                 connect_args=self._connect_args)
             print("WRDS recommends setting up a .pgpass file.")
             print("You can find more info here:")


### PR DESCRIPTION
SQLAlchemy inserts an implicit BEGIN (starts a transaction)
This can cause an error if connection is closed remotely/ disconnected even if connection is not used again
Also prevents disconnect of a long running query that is running during some types of publishes (table updates)
isolation_level available in SQLAlchemy 0.8.2