### PR TITLE
Set Default Username to Supplied Value When Prompting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ requires = [
 
 setup(
     name='wrds',
-    version='3.0.8',
+    version='3.0.10',
     description="Python access to WRDS Data",
     long_description=open('README.rst').read(),
     author='WRDS',

--- a/wrds/__init__.py
+++ b/wrds/__init__.py
@@ -25,7 +25,7 @@ WRDS-Py is a library for extracting data from WRDS data sources and getting it i
 """
 
 __title__ = 'wrds-py'
-__version__ = '3.0.9'
+__version__ = '3.0.10'
 __author__ = 'Wharton Research Data Services'
 __copyright__ = '2017-2021 Wharton Research Data Services'
 

--- a/wrds/sql.py
+++ b/wrds/sql.py
@@ -173,7 +173,10 @@ class Connection(object):
 
         >>> user,passwd = wrds.Connection.__get_user_credentials()
         """
-        uname = getpass.getuser()
+        if (self._username):
+            uname = self._username
+        else:
+            uname = getpass.getuser()
         username = input("Enter your WRDS username [{}]:".format(uname))
         if not username:
             username = uname


### PR DESCRIPTION
This branch covers an edge case where a username specified in `wrds.Connection(wrds_username='<username>')` gets excluded on a (re-)prompt for credentials. Specifically, when the custom user does not exist as a `.pgpass` entry but you supplied the username when creating the object, the value is ignored.

Before:
```
>>> import wrds
>>> db = wrds.Connection(wrds_username='testXX')
Enter your WRDS username [vjef]:
...
```

After:
```
>>> import wrds
>>> db = wrds.Connection(wrds_username='testXX')
Enter your WRDS username [testXX]:
...
```

The value you gave for `wrds_username` then becomes the default in the prompt, instead of reverting to your logged-in user via `getpass.getuser()`. The change mainly corrects an annoyance, but it is useful. It might be even better to skip a prompt for username if one is provided, but I'm taking the shortest path initially.
