### PR TITLE
Create .pgpass automatically if user desires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ requires = [
 
 setup(
     name='wrds',
-    version='3.0.10',
+    version='3.0.11',
     description="Python access to WRDS Data",
     long_description=open('README.rst').read(),
     author='WRDS',

--- a/wrds/sql.py
+++ b/wrds/sql.py
@@ -116,10 +116,6 @@ class Connection(object):
                     dbname=self._dbname),
                 isolation_level="AUTOCOMMIT",
                 connect_args=self._connect_args)
-            print("WRDS recommends setting up a .pgpass file.")
-            print("You can find more info here:")
-            print("https://www.postgresql.org"
-                  "/docs/9.5/static/libpq-pgpass.html.")
             try:
                 self.connection = self.engine.connect()
             except Exception as e:
@@ -127,6 +123,22 @@ class Connection(object):
                 self._username = None
                 self._password = None
                 raise e
+
+            # Connection successful. Offer to create a .pgpass for the user.
+            print("WRDS recommends setting up a .pgpass file.")
+            do_create_pgpass = ""
+            while do_create_pgpass != "y" and do_create_pgpass != "n":
+                do_create_pgpass = input("Create .pgpass file now [y/n]?: ")
+
+            if do_create_pgpass == "y":
+                try:
+                    self.create_pgpass_file()
+                    print("Created .pgpass file successfully.")
+                except:
+                    print("Failed to create .pgpass file. Please try manually with the create_pgpass_file() function.")
+            else:
+                print("You can create this file yourself at any time")
+                print("with the create_pgpass_file() function.")
 
     def close(self):
         """


### PR DESCRIPTION
This branch provides the ability to create a `.pgpass` file for the user automatically if they choose. After a user without a `.pgpass` authenticates and connects successfully to Postgres, they receive a prompt asking to create the file for them. Normal yes/no routing ensues.

These prompts also replace our old outputs directing users to Postgres documentation for info on how to create the `.pgpass` file themselves. Since we give them this ability already in this module, we might as well make use of it. Besides, we were pointing everybody to Postgres 9.5 documentation.

I have tested this code both with and without a pre-existing `.pgpass`. As always, I encourage further testing and feedback. Thanks!