### PR TITLE
Problems caused by omitting schemas that end in '_all' 

### DIFF
--- a/wrds/sql.py
+++ b/wrds/sql.py
@@ -161,7 +161,7 @@ class Connection(object):
         cursor = self.connection.execute(query)
         self.schema_perm = [x[0] for x in cursor.fetchall()
                             if not (x[0].endswith('_old') or
-                                    x[0].endswith('_all'))]
+                                    x[0].endswith('_new'))]
         print("Done")
 
     def __get_user_credentials(self):


### PR DESCRIPTION
Omitting some schemas that end in '_all' causes some operations (ie list_tables) to incorrectly warn user does not have access

While most schemas ending in '_all' contain views pointing to actual tables, some actually contain the datatables, they need to be in the library list
additionally omit schemas that end in '_new' b/c those or always transient/aborted publishes