### PR TITLE
Allow Server to Appear Multiple Times in .pgpass

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ requires = [
 
 setup(
     name='wrds',
-    version='3.0.11',
+    version='3.0.12',
     description="Python access to WRDS Data",
     long_description=open('README.rst').read(),
     author='WRDS',

--- a/wrds/__init__.py
+++ b/wrds/__init__.py
@@ -25,7 +25,7 @@ WRDS-Py is a library for extracting data from WRDS data sources and getting it i
 """
 
 __title__ = 'wrds-py'
-__version__ = '3.0.11'
+__version__ = '3.0.12'
 __author__ = 'Wharton Research Data Services'
 __copyright__ = '2017-2021 Wharton Research Data Services'
 

--- a/wrds/sql.py
+++ b/wrds/sql.py
@@ -301,6 +301,17 @@ class Connection(object):
                     newlines.append(newline)
                 else:
                     newlines.append(line)
+
+            # Add line for current user/password - enables multiple wrds-pgdata entries with
+            # different usernames
+            newline = pgpass.format(
+                host=self._hostname,
+                port=self._port,
+                dbname=self._dbname,
+                user=self._username,
+                passwd=passwd)
+            if newline not in newlines:
+                newlines.append(newline)
             lines = newlines
         else:
             line = pgpass.format(


### PR DESCRIPTION
This branch enables writing multiple lines for the same server in `.pgpass` when the username differs from existing lines. Current behavior is to overwrite an entry for a server using the current credentials, regardless of what username exists in the file already. The basic flow is an add-on, where I construct the line for the current user, check whether that line is in the collection of lines found in an existing `.pgpass`, and add the line to the collection if it is not already present. This preserves existing functionality, like updating an existing `.pgpass` entry when a user password has changed.