### PR TITLE
Do chunking behind the scenes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ requires = [
 
 setup(
     name='wrds',
-    version='3.0.11',
+    version='3.1.0',
     description="Python access to WRDS Data",
     long_description=open('README.rst').read(),
     author='WRDS',

--- a/wrds/__init__.py
+++ b/wrds/__init__.py
@@ -25,7 +25,7 @@ WRDS-Py is a library for extracting data from WRDS data sources and getting it i
 """
 
 __title__ = 'wrds-py'
-__version__ = '3.0.11'
+__version__ = '3.1.0'
 __author__ = 'Wharton Research Data Services'
 __copyright__ = '2017-2021 Wharton Research Data Services'
 

--- a/wrds/sql.py
+++ b/wrds/sql.py
@@ -465,7 +465,8 @@ class Connection(object):
             print("There was a problem with retrieving the schema")
             return None
 
-    def raw_sql(self, sql, coerce_float=True, date_cols=None, index_col=None, params=None):
+    def raw_sql(self, sql, coerce_float=True, date_cols=None, index_col=None, params=None,
+        chunksize=500000, return_iter=False):
         """
             Queries the database using a raw SQL string.
 
@@ -487,8 +488,16 @@ class Connection(object):
               default: None
                 Column(s) to set as index(MultiIndex)
             :param params: parameters to SQL query, if parameterized.
+            :param chunksize: (optional) integer or None default: 500000
+                Process query in chunks of this size. Smaller chunksizes can save
+                a considerable amount of memory while query is being processed.
+                Set to None run query w/o chunking.
+            :param return_iter: (optional) boolean, default:False
+                When chunksize is not None, return an iterator where chunksize
+                number of rows is included in each chunk.
 
-            :rtype: pandas.DataFrame
+            :rtype: pandas.DataFrame or or Iterator[pandas.DataFrame]
+
 
             Usage ::
             # Basic Usage
@@ -513,14 +522,24 @@ class Connection(object):
                 2003-09-10  16:10:35.522000  T        A       None        B   71900.0  24.918          N      00  1.929970e+15         C  None
                 2003-09-10  09:35:20.709000  N       AA       None     None  108100.0  28.200          N      00  1.929947e+15         C  None
         """
+
         try:
-            return pd.read_sql_query(
+
+            df = pd.read_sql_query(
                 sql,
                 self.connection,
                 coerce_float=coerce_float,
                 parse_dates=date_cols,
                 index_col=index_col,
+                chunksize=chunksize,
                 params=params)
+            if return_iter or chunksize is None:
+                return df
+            else:
+                full_df = pd.DataFrame()
+                for chunk in df:
+                    full_df = pd.concat([full_df, chunk])
+                return full_df
         except sa.exc.ProgrammingError as e:
             raise e
 


### PR DESCRIPTION
Allow chunksize to be overridden add ability to request iterator
The new default behavior reduces memory consumption for very large result sets
Unclear where savings occurs - ie in Pandas or SQLAlchemy 