### PR TITLE
load_library_list will now only pull in schemas that contain at least one table/view user can access

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wrds"
-version = "3.1.0"
+version = "3.1.1"
 description = "Python access to WRDS Data"
 authors = [
     "Eric Stein <ericst@wharton.upenn.edu>",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ requires = [
 
 setup(
     name='wrds',
-    version='3.1.0',
+    version='3.1.1',
     description="Python access to WRDS Data",
     long_description=open('README.rst').read(),
     author='WRDS',

--- a/wrds/__init__.py
+++ b/wrds/__init__.py
@@ -25,7 +25,7 @@ WRDS-Py is a library for extracting data from WRDS data sources and getting it i
 """
 
 __title__ = 'wrds-py'
-__version__ = '3.1.0'
+__version__ = '3.1.1'
 __author__ = 'Wharton Research Data Services'
 __copyright__ = '2017-2021 Wharton Research Data Services'
 

--- a/wrds/sql.py
+++ b/wrds/sql.py
@@ -421,7 +421,7 @@ ORDER BY 1 ;
         """
             Takes the library and the table and describes all the columns
               in that table.
-            Includes Column Name, Column Type, Nullable?.
+            Includes Column Name, Column Type, Nullable?, Comment
 
             :param library: Postgres schema name.
             :param table: Postgres table name.
@@ -430,7 +430,7 @@ ORDER BY 1 ;
 
             Usage::
             >>> db.describe_table('wrdssec_all', 'dforms')
-                        name nullable     type
+                        name nullable     type comment
                   0      cik     True  VARCHAR
                   1    fdate     True     DATE
                   2  secdate     True     DATE
@@ -442,7 +442,7 @@ ORDER BY 1 ;
         print("Approximately {} rows in {}.{}.".format(rows, library, table))
         table_info = pd.DataFrame.from_dict(
             self.insp.get_columns(table, schema=library))
-        return table_info[['name', 'nullable', 'type']]
+        return table_info[['name', 'nullable', 'type', 'comment']]
 
     def get_row_count(self, library, table):
         """


### PR DESCRIPTION
previously load_library_list would include schemas user has access to that *might* contain views that point to a table the user has access to
This included *all* "friendly named" schemas.

Use a different method to get approximate number of rows, simplifies code for views.
Now works for partitioned tables also (new TAQ format).

Add column comments to describe_table output
Column comments are new / soon to be added to tables.