### PR TITLE
Pin SQLAlchemy Package to <v2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wrds"
-version = "3.1.2"
+version = "3.1.3"
 description = "Python access to WRDS Data"
 authors =  [
     {name="Eric Stein", email="ericst@wharton.upenn.edu"},

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ packages = [
 requires = [
     'numpy',
     'pandas',
-    'sqlalchemy',
+    'sqlalchemy<2.0.0',
     'psycopg2-binary',
     # mock may need to be included if folks
     # want to run tests w/Py2
@@ -26,7 +26,7 @@ requires = [
 
 setup(
     name='wrds',
-    version='3.1.2',
+    version='3.1.3',
     description="Python access to WRDS Data",
     long_description=open('README.rst').read(),
     author='WRDS',

--- a/wrds/__init__.py
+++ b/wrds/__init__.py
@@ -25,7 +25,7 @@ WRDS-Py is a library for extracting data from WRDS data sources and getting it i
 """
 
 __title__ = 'wrds-py'
-__version__ = '3.1.2'
+__version__ = '3.1.3'
 __author__ = 'Wharton Research Data Services'
 __copyright__ = '2017-2021 Wharton Research Data Services'
 


### PR DESCRIPTION
This branch pins the prereq `sqlalchemy` package to less than v2.0.0. This is a stopgap measure to avoid errors until we evaluate 2.x versions of the package fully.

I tested building a new venv and installing this package with `python3 setup.py install`, which gave me v1.4.46 of `sqlalchemy`.