### PR TITLE
Fixed error when importing in Python 3.7

### DIFF
--- a/wrds/sql.py
+++ b/wrds/sql.py
@@ -92,7 +92,7 @@ class Connection(object):
             self.connection = self.engine.connect()
         except Exception as err:
             if self._verbose:
-                print(f"{err=}")
+                print(f"{err}")
             self.engine = None
             if raise_err:
                 raise err


### PR DESCRIPTION
`print(f"{err=}")` in `sql.py` is causing error when importing in Python 3.7. Changed to `print(f"{err}")` instead