### PR TITLE
This is Python - we use rows.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Approximately 58957 rows in crsp.stocknames.
 2      namedt      True              DATE
 ...
 
->>> stocknames = db.get_table(library='crsp', table='stocknames', obs=10) 
+>>> stocknames = db.get_table(library='crsp', table='stocknames', rows=10) 
 >>> stocknames.head()
    permno  permco      namedt   nameenddt     cusip    ncusip ticker  \
 0  10000.0  7952.0  1986-01-07  1987-06-11  68391610  68391610  OMFGA
@@ -59,7 +59,7 @@ Approximately 58957 rows in crsp.stocknames.
 >>> db.close()  # Close the connection to the database...
 
 >>> with wrds.Connection() as db:  # You can use a context manager
-...    stocknames = db.get_table(library='crsp', table='stocknames', obs=10)
+...    stocknames = db.get_table(library='crsp', table='stocknames', rows=10)
 >>> stocknames.head()
    permno  permco      namedt   nameenddt     cusip    ncusip ticker  \
 0  10000.0  7952.0  1986-01-07  1987-06-11  68391610  68391610  OMFGA


### PR DESCRIPTION
We'll keep obs around for backwards compatibility, but in the videos we're recording with this package, we should be using `rows`. `obs` has no meaning outside of SAS.